### PR TITLE
Leave off "in location" if event has no location

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,9 +30,14 @@ function makeMessage(event) {
 
     var date = moment(event.start.dateTime).format("h:mm A");
     var end = moment(event.end.dateTime).format("h:mm A");
+    if (!event.location) {
+        var location_string = "";   
+    } else {
+        var location_string = ` in ${event.location}`;   
+    }
 
     text["attachments"][0]["title"] = event["summary"];
-    text["attachments"][0]["text"] = `${date} - ${end} in ${event.location}`;
+    text["attachments"][0]["text"] = `${date} - ${end}${location_string}`;
     if (event["description"]) {
         text["attachments"][0]["text"] += `\n${event.description}`
     }


### PR DESCRIPTION
Before this change, and event that didn't have a location set would show up like this:
![image](https://user-images.githubusercontent.com/5790137/37248316-2345ed1c-249d-11e8-8f9f-267b7dc8298b.png)
